### PR TITLE
Support default conda queue environment

### DIFF
--- a/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_published_workflow.py
+++ b/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_published_workflow.py
@@ -475,6 +475,8 @@ class DeadlineCloudPublishedWorkflow(ControlNode, BaseDeadlineCloud):
             "DataDir": {"path": root_dir},
             "LocationToRemap": {"path": relative_dir_path},
             "ModelsLocationToRemap": {"path": models_dir_path},
+            "CondaChannels": {"string": self.get_parameter_value("conda_channels")},
+            "CondaPackages": {"string": self.get_parameter_value("conda_packages")},
         }
 
         job_template = self._reconcile_job_template(job_template)

--- a/griptape_nodes_library_deadline_cloud/publish/parameters/deadline_cloud_job_submission_config_advanced_parameter.py
+++ b/griptape_nodes_library_deadline_cloud/publish/parameters/deadline_cloud_job_submission_config_advanced_parameter.py
@@ -98,6 +98,24 @@ class DeadlineCloudJobSubmissionConfigAdvancedParameter:
                 tooltip="The storage profile ID for the Deadline Cloud Job.",
                 allowed_modes=allowed_modes,
             )
+            Parameter(
+                name="conda_channels",
+                input_types=["str"],
+                type="str",
+                default_value="conda-forge",
+                output_type="str",
+                tooltip="Conda channels to install packages from.",
+                allowed_modes=allowed_modes,
+            )
+            Parameter(
+                name="conda_packages",
+                input_types=["str"],
+                type="str",
+                default_value="python=3.12",
+                output_type="str",
+                tooltip="Conda packages install job.",
+                allowed_modes=allowed_modes,
+            )
 
         job_submission_config_group_advanced.ui_options = {"hide": False, "collapsed": True}
         self.node.add_node_element(job_submission_config_group_advanced)
@@ -112,4 +130,6 @@ class DeadlineCloudJobSubmissionConfigAdvancedParameter:
             "farm_id",
             "queue_id",
             "storage_profile_id",
+            "conda_channels",
+            "conda_packages",
         ]


### PR DESCRIPTION
This plugin currently requires a custom queue environment to install python 3.12 from conda-forge. Deadline queues have a default queue environment that supports installing conda packages if the job has CondaChannels and CondaPackages parameters set. This PR adds those two parameters with default values. With this PR, jobs work without a custom queue environment.