### PR TITLE
fix: correct package name and remove deprecated storage_backend kwarg

### DIFF
--- a/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_job_template_generator.py
+++ b/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_job_template_generator.py
@@ -304,7 +304,6 @@ if __name__ == "__main__":
     )
     execute_workflow(
         input=flow_input,
-        storage_backend="local",
         workflow_executor=workflow_runner,
         pickle_control_flow_result=pickle_result,
     )

--- a/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_multi_task_publisher.py
+++ b/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_multi_task_publisher.py
@@ -291,7 +291,7 @@ class DeadlineCloudMultiTaskPublisher(DeadlineCloudPublisher):
 
             with (assets_dir / "requirements.txt").open("w", encoding="utf-8") as req_file:
                 req_file.write(
-                    f"griptape-nodes-engine @ git+https://github.com/griptape-ai/griptape-nodes.git@{engine_version}\n"
+                    f"griptape-nodes-engine @ git+https://github.com/griptape-ai/griptape-nodes-engine.git@{engine_version}\n"
                 )
                 for library_ref in node_libraries:
                     lib = LibraryRegistry.get_library(library_ref.library_name)

--- a/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_multi_task_publisher.py
+++ b/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_multi_task_publisher.py
@@ -291,7 +291,7 @@ class DeadlineCloudMultiTaskPublisher(DeadlineCloudPublisher):
 
             with (assets_dir / "requirements.txt").open("w", encoding="utf-8") as req_file:
                 req_file.write(
-                    f"griptape-nodes @ git+https://github.com/griptape-ai/griptape-nodes.git@{engine_version}\n"
+                    f"griptape-nodes-engine @ git+https://github.com/griptape-ai/griptape-nodes.git@{engine_version}\n"
                 )
                 for library_ref in node_libraries:
                     lib = LibraryRegistry.get_library(library_ref.library_name)

--- a/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_multi_task_template_generator.py
+++ b/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_multi_task_template_generator.py
@@ -362,7 +362,6 @@ if __name__ == "__main__":
     # Execute the workflow
     result = execute_workflow(
         input=flow_input,
-        storage_backend="local",
         workflow_executor=workflow_runner,
         pickle_control_flow_result=pickle_result,
     )

--- a/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_publisher.py
+++ b/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_publisher.py
@@ -1156,7 +1156,7 @@ class DeadlineCloudPublisher(BaseDeadlineCloud):
 
             with (assets_dir / "requirements.txt").open("w", encoding="utf-8") as req_file:
                 req_file.write(
-                    f"griptape-nodes @ git+https://github.com/griptape-ai/griptape-nodes.git@{engine_version}\n"
+                    f"griptape-nodes-engine @ git+https://github.com/griptape-ai/griptape-nodes.git@{engine_version}\n"
                 )
                 # Libraries may be registered locally with a no-deps JSON variant
                 # (e.g. griptape-nodes-library-no-deps.json) to avoid installing heavy

--- a/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_publisher.py
+++ b/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_publisher.py
@@ -1156,7 +1156,7 @@ class DeadlineCloudPublisher(BaseDeadlineCloud):
 
             with (assets_dir / "requirements.txt").open("w", encoding="utf-8") as req_file:
                 req_file.write(
-                    f"griptape-nodes-engine @ git+https://github.com/griptape-ai/griptape-nodes.git@{engine_version}\n"
+                    f"griptape-nodes-engine @ git+https://github.com/griptape-ai/griptape-nodes-engine.git@{engine_version}\n"
                 )
                 # Libraries may be registered locally with a no-deps JSON variant
                 # (e.g. griptape-nodes-library-no-deps.json) to avoid installing heavy


### PR DESCRIPTION
## Summary

- Use `griptape-nodes-engine` instead of `griptape-nodes` in generated `requirements.txt`. The git repo's `pyproject.toml` declares the project name as `griptape-nodes-engine`, causing pip to reject the egg name mismatch when installing on workers.
- Remove `storage_backend="local"` from `execute_workflow()` calls in generated worker scripts. Engine v0.86.0 deprecated this parameter on `aprepare_workflow_for_run()`; the backend is already set correctly in the `DeadlineCloudWorkflowExecutor` constructor.

## Test plan

- [x] Ran `deadline_cloud_wedge_test.py` E2E workflow through GTN → Deadline Cloud
- [x] Job `job-8d50543af03c411084249f15c4864657` completed successfully with all 3 tasks SUCCEEDED
- [x] Output images downloaded and written to local outputs directory