### PR TITLE
fix: install worker deps with uv on Python 3.12 (issue #106)

### DIFF
--- a/griptape_nodes_library_deadline_cloud/execution/deadline_cloud_multi_task_group.py
+++ b/griptape_nodes_library_deadline_cloud/execution/deadline_cloud_multi_task_group.py
@@ -24,6 +24,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
+
 from publish import LIBRARY_NAME
 from publish.deadline_cloud_end_flow import DeadlineCloudEndFlow
 from publish.deadline_cloud_start_flow import DeadlineCloudStartFlow

--- a/griptape_nodes_library_deadline_cloud/publish/base_deadline_cloud.py
+++ b/griptape_nodes_library_deadline_cloud/publish/base_deadline_cloud.py
@@ -14,6 +14,7 @@ from deadline.client.config import get_setting_default
 from griptape_nodes.retained_mode.griptape_nodes import (
     GriptapeNodes,
 )
+
 from publish import DEADLINE_CLOUD_LIBRARY_CONFIG_KEY
 
 if TYPE_CHECKING:

--- a/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_job_template_generator.py
+++ b/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_job_template_generator.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, Any
 
 import yaml
 
+from publish.utils import build_venv_script
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -18,7 +20,12 @@ class DeadlineCloudJobTemplateGenerator:
 
     @staticmethod
     def generate_job_template(
-        job_bundle_dir: Path, workflow_name: str, library_paths: list[str], *, pickle_control_flow_result: bool = False
+        job_bundle_dir: Path,
+        workflow_name: str,
+        library_paths: list[str],
+        *,
+        pickle_control_flow_result: bool = False,
+        pip_install_flags: list[str] | None = None,
     ) -> dict[str, Any]:
         """Generate Open Job Description template for the workflow."""
         parameter_definitions: list[dict[str, Any]] = []
@@ -81,7 +88,16 @@ class DeadlineCloudJobTemplateGenerator:
                 "name": "CondaPackages",
                 "type": "STRING",
                 "description": "Conda packages install job",
-                "default": "python=3.12 pip git",
+                "default": "python=3.12 pip git uv",
+            }
+        )
+
+        parameter_definitions.append(
+            {
+                "name": "PipInstallFlags",
+                "type": "STRING",
+                "description": "uv-only install flags (e.g. --torch-backend=auto) from referenced libraries",
+                "default": " ".join(pip_install_flags or []),
             }
         )
 
@@ -90,27 +106,7 @@ class DeadlineCloudJobTemplateGenerator:
             library_paths, pickle_control_flow_result=pickle_control_flow_result
         )
 
-        venv_script = """#!/bin/env bash
-set -e
-echo 'Setting up Python virtual environment...'
-python -m pip install --upgrade pip wheel setuptools
-echo 'Installing dependencies...'
-pip install -r {{Param.LocationToRemap}}/assets/requirements.txt
-mkdir -p {{Param.LocationToRemap}}/output
-
-# Create .venv symlinks in libraries so library code that expects its own
-# venv (e.g. _get_library_env_python) finds a working Python with all deps.
-SESSION_PYTHON=$(which python)
-for lib_dir in {{Param.LocationToRemap}}/assets/libraries/*/; do
-    if [ -f "${lib_dir}griptape-nodes-library.json" ] || [ -f "${lib_dir}griptape-nodes-library-cuda129.json" ]; then
-        mkdir -p "${lib_dir}.venv/bin"
-        ln -sf "$SESSION_PYTHON" "${lib_dir}.venv/bin/python"
-        echo "Created .venv symlink in ${lib_dir}"
-    fi
-done
-
-echo 'Virtual environment setup complete.'
-"""
+        venv_script = build_venv_script()
 
         # Create job template
         job_template: dict[str, Any] = {

--- a/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_multi_task_publisher.py
+++ b/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_multi_task_publisher.py
@@ -28,11 +28,17 @@ from griptape_nodes.retained_mode.events.workflow_events import (
     SaveWorkflowFileFromSerializedFlowResultSuccess,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
 from publish import DEADLINE_CLOUD_LIBRARY_CONFIG_KEY
 from publish.deadline_cloud_job_poller import DeadlineCloudJobPoller
 from publish.deadline_cloud_multi_task_template_generator import DeadlineCloudMultiTaskJobTemplateGenerator
 from publish.deadline_cloud_publisher import DeadlineCloudPublisher
-from publish.utils import collect_metadata_sidecars, write_sidecar_output_files
+from publish.utils import (
+    collect_metadata_sidecars,
+    collect_pip_install_flags,
+    write_library_deps,
+    write_sidecar_output_files,
+)
 
 if TYPE_CHECKING:
     from deadline.job_attachments.models import StorageProfile
@@ -192,7 +198,7 @@ class DeadlineCloudMultiTaskPublisher(DeadlineCloudPublisher):
         # Get libraries from node_dependencies
         return list(serialized_flow.node_dependencies.libraries)
 
-    def _package_multi_task_workflow(self, workflow_file_path: Path) -> str:  # noqa: C901, PLR0915
+    def _package_multi_task_workflow(self, workflow_file_path: Path) -> str:  # noqa: PLR0915
         """Package the workflow as a Deadline Cloud job bundle for multi-task execution.
 
         Args:
@@ -289,6 +295,10 @@ class DeadlineCloudMultiTaskPublisher(DeadlineCloudPublisher):
             if source == "git" and commit_id is not None:
                 engine_version = commit_id
 
+            # uv-only install flags collected from referenced libraries; passed on
+            # the worker's `uv pip install` command line via PipInstallFlags rather
+            # than written into requirements.txt (which plain pip would reject).
+            pip_install_flags: list[str] = []
             with (assets_dir / "requirements.txt").open("w", encoding="utf-8") as req_file:
                 req_file.write(
                     f"griptape-nodes-engine @ git+https://github.com/griptape-ai/griptape-nodes-engine.git@{engine_version}\n"
@@ -298,16 +308,13 @@ class DeadlineCloudMultiTaskPublisher(DeadlineCloudPublisher):
                     library_data = lib.get_library_data()
                     deps = library_data.metadata.dependencies
                     if deps and deps.pip_dependencies:
-                        if deps.pip_install_flags:
-                            req_file.write(f"{' '.join(deps.pip_install_flags)}\n")
-                        for dep in deps.pip_dependencies:
-                            if dep.startswith("-e"):
-                                continue
-                            req_file.write(f"{dep}\n")
+                        write_library_deps(req_file, deps)
+                        lib_flags = collect_pip_install_flags([deps])
                     else:
                         # Fallback: check for a sibling library JSON with deps
                         # (handles no-deps variants used for local dev)
-                        self._write_deps_from_sibling_json(library_ref.library_name, req_file)
+                        lib_flags = self._write_deps_from_sibling_json(library_ref.library_name, req_file)
+                    pip_install_flags.extend(f for f in lib_flags if f not in pip_install_flags)
 
             # 7. Gather and copy static file dependencies from FileSelector nodes
             file_selector_nodes = self._gather_file_selector_nodes()
@@ -325,6 +332,7 @@ class DeadlineCloudMultiTaskPublisher(DeadlineCloudPublisher):
                 task_count=self.task_count,
                 pickle_control_flow_result=self._multi_task_config.pickle_control_flow_result,
                 host_requirements=self._multi_task_config.host_requirements,
+                pip_install_flags=pip_install_flags,
             )
 
             logger.info("Multi-task job bundle created at: %s", job_bundle_dir)
@@ -488,6 +496,7 @@ class DeadlineCloudMultiTaskPublisher(DeadlineCloudPublisher):
             GetParameterValueRequest,
             GetParameterValueResultSuccess,
         )
+
         from publish.deadline_cloud_publisher import (
             FILE_SELECTOR_LIBRARY_NAME,
             SELECT_FROM_PROJECT_NODE_TYPE,

--- a/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_multi_task_template_generator.py
+++ b/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_multi_task_template_generator.py
@@ -12,6 +12,8 @@ from typing import TYPE_CHECKING, Any
 
 import yaml
 
+from publish.utils import build_venv_script
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -35,6 +37,7 @@ class DeadlineCloudMultiTaskJobTemplateGenerator:
         *,
         pickle_control_flow_result: bool = False,
         host_requirements: dict[str, Any] | None = None,
+        pip_install_flags: list[str] | None = None,
     ) -> dict[str, Any]:
         """Generate Open Job Description template for a multi-task workflow.
 
@@ -45,6 +48,7 @@ class DeadlineCloudMultiTaskJobTemplateGenerator:
             task_count: Number of tasks to create (one per iteration item)
             pickle_control_flow_result: Whether to pickle control flow results
             host_requirements: Optional host requirements dict with 'amounts' and/or 'attributes'
+            pip_install_flags: uv-only install flags collected from referenced libraries
 
         Returns:
             The generated job template dictionary
@@ -108,7 +112,16 @@ class DeadlineCloudMultiTaskJobTemplateGenerator:
                 "name": "CondaPackages",
                 "type": "STRING",
                 "description": "Conda packages install job",
-                "default": "python=3.12 pip git",
+                "default": "python=3.12 pip git uv",
+            }
+        )
+
+        parameter_definitions.append(
+            {
+                "name": "PipInstallFlags",
+                "type": "STRING",
+                "description": "uv-only install flags (e.g. --torch-backend=auto) from referenced libraries",
+                "default": " ".join(pip_install_flags or []),
             }
         )
 
@@ -117,27 +130,7 @@ class DeadlineCloudMultiTaskJobTemplateGenerator:
             library_paths, pickle_control_flow_result=pickle_control_flow_result
         )
 
-        venv_script = """#!/bin/env bash
-set -e
-echo 'Setting up Python virtual environment...'
-python -m pip install --upgrade pip wheel setuptools
-echo 'Installing dependencies...'
-pip install -r {{Param.LocationToRemap}}/assets/requirements.txt
-mkdir -p {{Param.LocationToRemap}}/output
-
-# Create .venv symlinks in libraries so library code that expects its own
-# venv (e.g. _get_library_env_python) finds a working Python with all deps.
-SESSION_PYTHON=$(which python)
-for lib_dir in {{Param.LocationToRemap}}/assets/libraries/*/; do
-    if [ -f "${lib_dir}griptape-nodes-library.json" ] || [ -f "${lib_dir}griptape-nodes-library-cuda129.json" ]; then
-        mkdir -p "${lib_dir}.venv/bin"
-        ln -sf "$SESSION_PYTHON" "${lib_dir}.venv/bin/python"
-        echo "Created .venv symlink in ${lib_dir}"
-    fi
-done
-
-echo 'Virtual environment setup complete.'
-"""
+        venv_script = build_venv_script()
 
         # Create job template with parameterSpace for multi-task execution
         job_template: dict[str, Any] = {

--- a/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_published_workflow.py
+++ b/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_published_workflow.py
@@ -24,6 +24,7 @@ from griptape_nodes.retained_mode.events.os_events import (
     CopyFileResultSuccess,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
 from publish.base_deadline_cloud import BaseDeadlineCloud
 from publish.deadline_cloud_job_poller import DeadlineCloudJobDetails, DeadlineCloudJobPoller
 from publish.parameters.deadline_cloud_host_config_parameter import DeadlineCloudHostConfigParameter
@@ -34,7 +35,7 @@ from publish.parameters.deadline_cloud_job_submission_config_advanced_parameter 
     DeadlineCloudJobSubmissionConfigAdvancedParameter,
 )
 from publish.parameters.deadline_cloud_job_submission_config_parameter import DeadlineCloudJobSubmissionConfigParameter
-from publish.utils import collect_metadata_sidecars, write_sidecar_output_files
+from publish.utils import collect_metadata_sidecars, ensure_conda_package, write_sidecar_output_files
 
 if TYPE_CHECKING:
     from deadline.job_attachments.models import StorageProfile
@@ -633,9 +634,12 @@ class DeadlineCloudPublishedWorkflow(SuccessFailureNode, BaseDeadlineCloud):
     @staticmethod
     def _ensure_conda_git(conda_packages: str) -> str:
         """Ensure git is included in conda packages (needed for pip git+ installs)."""
-        if "git" not in conda_packages.split():
-            conda_packages = f"{conda_packages} git"
-        return conda_packages
+        return ensure_conda_package(conda_packages, "git")
+
+    @staticmethod
+    def _ensure_conda_uv(conda_packages: str) -> str:
+        """Ensure uv is included in conda packages (the worker installs deps with uv)."""
+        return ensure_conda_package(conda_packages, "uv")
 
     def _reconcile_job_template(self, job_template: dict[str, Any]) -> dict[str, Any]:
         """Reconcile the job template with the parameters."""
@@ -849,7 +853,9 @@ class DeadlineCloudPublishedWorkflow(SuccessFailureNode, BaseDeadlineCloud):
                 "ModelsLocationToRemap": {"path": models_dir_path},
                 "OutputDir": {"string": output_dir_subdir},
                 "CondaChannels": {"string": self.get_parameter_value("conda_channels")},
-                "CondaPackages": {"string": self._ensure_conda_git(self.get_parameter_value("conda_packages"))},
+                "CondaPackages": {
+                    "string": self._ensure_conda_uv(self._ensure_conda_git(self.get_parameter_value("conda_packages")))
+                },
             }
 
             job_template = self._reconcile_job_template(job_template)

--- a/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_publisher.py
+++ b/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_publisher.py
@@ -69,6 +69,7 @@ from griptape_nodes.retained_mode.griptape_nodes import (
     GriptapeNodes,
 )
 from huggingface_hub.constants import HF_HUB_CACHE
+
 from publish import DEADLINE_CLOUD_LIBRARY_CONFIG_KEY, LIBRARY_NAME
 from publish.base_deadline_cloud import BaseDeadlineCloud
 from publish.deadline_cloud_job_template_generator import (
@@ -78,7 +79,7 @@ from publish.deadline_cloud_workflow_builder import (
     DeadlineCloudWorkflowBuilder,
     DeadlineCloudWorkflowBuilderInput,
 )
-from publish.utils import get_metadata_dir_name
+from publish.utils import collect_pip_install_flags, get_metadata_dir_name, write_library_deps
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -87,6 +88,7 @@ if TYPE_CHECKING:
     from deadline.job_attachments.models import StorageProfile
     from griptape_nodes.retained_mode.events.base_events import ResultPayload
     from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
+
     from publish.deadline_cloud_start_flow import DeadlineCloudStartFlow
 
 
@@ -1013,16 +1015,20 @@ class DeadlineCloudPublisher(BaseDeadlineCloud):
         for key, val in env_file_dict.items():
             set_key(env_file_path, key, str(val))
 
-    def _write_deps_from_sibling_json(self, library_name: str, req_file: Any) -> None:
+    def _write_deps_from_sibling_json(self, library_name: str, req_file: Any) -> list[str]:
         """Look for a sibling library JSON with pip_dependencies.
 
         When a library is registered with a no-deps variant, look for the full
         version (e.g. griptape-nodes-library.json or *-cuda*.json) in the same
         directory to get the actual pip_dependencies for remote execution.
+
+        Returns the sibling's ``pip_install_flags`` (uv-only flags) so the caller
+        can pass them on the ``uv pip install`` command line rather than writing
+        them into requirements.txt (which plain pip would reject).
         """
         library = GriptapeNodes.LibraryManager().get_library_info_by_library_name(library_name)
         if library is None or not library.library_path.endswith(".json"):
-            return
+            return []
 
         library_json_path = Path(library.library_path).resolve()
         library_dir = library_json_path.parent
@@ -1039,17 +1045,15 @@ class DeadlineCloudPublisher(BaseDeadlineCloud):
                 deps = data.get("metadata", {}).get("dependencies", {})
                 pip_deps = deps.get("pip_dependencies", [])
                 if pip_deps:
-                    pip_flags = deps.get("pip_install_flags", [])
-                    if pip_flags:
-                        req_file.write(f"{' '.join(pip_flags)}\n")
                     for dep in pip_deps:
                         if dep.startswith("-e"):
                             continue
                         req_file.write(f"{dep}\n")
                     logger.info("Using pip_dependencies from '%s' for library '%s'", candidate.name, library_name)
-                    return
+                    return deps.get("pip_install_flags", []) or []
             except Exception:  # noqa: S112
                 continue
+        return []
 
     def _get_engine_version_for_workflow(self, workflow: Workflow) -> str:
         # Get engine version for dependencies
@@ -1062,7 +1066,7 @@ class DeadlineCloudPublisher(BaseDeadlineCloud):
         engine_version_success = cast("GetEngineVersionResultSuccess", engine_version_result)
         return f"v{engine_version_success.major}.{engine_version_success.minor}.{engine_version_success.patch}"
 
-    def _package_workflow(self, workflow_name: str) -> str:  # noqa: C901, PLR0912, PLR0915
+    def _package_workflow(self, workflow_name: str) -> str:  # noqa: C901, PLR0915
         """Package workflow as a Deadline Cloud job bundle with Open Job Description template."""
         config_manager = GriptapeNodes.get_instance()._config_manager
         secrets_manager = GriptapeNodes.get_instance()._secrets_manager
@@ -1154,6 +1158,11 @@ class DeadlineCloudPublisher(BaseDeadlineCloud):
             if source == "git" and commit_id is not None:
                 engine_version = commit_id
 
+            # uv-only install flags (e.g. --preview, --torch-backend=auto) collected
+            # from referenced libraries. These are passed on the worker's
+            # `uv pip install` command line via the PipInstallFlags job parameter,
+            # not written into requirements.txt (which plain pip would reject).
+            pip_install_flags: list[str] = []
             with (assets_dir / "requirements.txt").open("w", encoding="utf-8") as req_file:
                 req_file.write(
                     f"griptape-nodes-engine @ git+https://github.com/griptape-ai/griptape-nodes-engine.git@{engine_version}\n"
@@ -1169,14 +1178,11 @@ class DeadlineCloudPublisher(BaseDeadlineCloud):
                     library_data = lib.get_library_data()
                     deps = library_data.metadata.dependencies
                     if deps and deps.pip_dependencies:
-                        if deps.pip_install_flags:
-                            req_file.write(f"{' '.join(deps.pip_install_flags)}\n")
-                        for dep in deps.pip_dependencies:
-                            if dep.startswith("-e"):
-                                continue
-                            req_file.write(f"{dep}\n")
+                        write_library_deps(req_file, deps)
+                        lib_flags = collect_pip_install_flags([deps])
                     else:
-                        self._write_deps_from_sibling_json(library_ref.library_name, req_file)
+                        lib_flags = self._write_deps_from_sibling_json(library_ref.library_name, req_file)
+                    pip_install_flags.extend(f for f in lib_flags if f not in pip_install_flags)
 
             # 6. Gather and copy static file dependencies from FileSelector nodes
             file_selector_nodes = self._gather_file_selector_nodes()
@@ -1188,7 +1194,11 @@ class DeadlineCloudPublisher(BaseDeadlineCloud):
 
             # 8. Generate Job Template
             self._job_template = DeadlineCloudJobTemplateGenerator.generate_job_template(
-                job_bundle_dir, workflow_name, library_paths, pickle_control_flow_result=self.pickle_control_flow_result
+                job_bundle_dir,
+                workflow_name,
+                library_paths,
+                pickle_control_flow_result=self.pickle_control_flow_result,
+                pip_install_flags=pip_install_flags,
             )
 
             logger.info("Job bundle created at: %s", job_bundle_dir)

--- a/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_start_flow.py
+++ b/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_start_flow.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import StartNode
+
 from publish.parameters.deadline_cloud_host_config_parameter import DeadlineCloudHostConfigParameter
 from publish.parameters.deadline_cloud_job_attachments_config_parameter import (
     DeadlineCloudJobAttachmentsConfigParameter,

--- a/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_workflow_builder.py
+++ b/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_workflow_builder.py
@@ -18,6 +18,7 @@ from griptape_nodes.retained_mode.events.node_events import (
 )
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
 from publish import LIBRARY_NAME
 from publish.deadline_cloud_end_flow import DeadlineCloudEndFlow
 from publish.deadline_cloud_published_workflow import DeadlineCloudPublishedWorkflow

--- a/griptape_nodes_library_deadline_cloud/publish/parameters/deadline_cloud_job_submission_config_advanced_parameter.py
+++ b/griptape_nodes_library_deadline_cloud/publish/parameters/deadline_cloud_job_submission_config_advanced_parameter.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup, ParameterMessage, ParameterMode
 from griptape_nodes.exe_types.node_types import BaseNode
+
 from publish.base_deadline_cloud import BaseDeadlineCloud
 from publish.deadline_cloud_resource_options import DeadlineCloudResourceOptions
 
@@ -140,7 +141,7 @@ class DeadlineCloudJobSubmissionConfigAdvancedParameter(BaseDeadlineCloud):
                 name="conda_packages",
                 input_types=["str"],
                 type="str",
-                default_value="python=3.12 git",
+                default_value="python=3.12 pip git uv",
                 output_type="str",
                 tooltip="Conda packages install job.",
                 allowed_modes=allowed_modes,

--- a/griptape_nodes_library_deadline_cloud/publish/utils.py
+++ b/griptape_nodes_library_deadline_cloud/publish/utils.py
@@ -14,12 +14,119 @@ from griptape_nodes.retained_mode.events.project_events import (
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from pathlib import Path
+    from typing import TextIO
+
+    from griptape_nodes.node_library.library_registry import Dependencies
 
 logger = logging.getLogger(__name__)
 
 # The situation name that defines where metadata sidecars are saved.
 METADATA_SITUATION_NAME = "save_griptape_nodes_metadata"
+
+
+def write_library_deps(req_file: TextIO, deps: Dependencies) -> None:
+    """Write a library's pip_dependencies into a requirements.txt file handle.
+
+    Editable installs (``-e ...``) are skipped because they reference local
+    checkouts that do not exist on the worker.
+
+    ``pip_install_flags`` are intentionally NOT written here. They are uv-only
+    CLI flags (e.g. ``--preview``, ``--torch-backend=auto``) that plain pip
+    rejects, so they are passed on the ``uv pip install`` command line via the
+    ``PipInstallFlags`` job parameter instead of being embedded in the file.
+    """
+    for dep in deps.pip_dependencies or []:
+        if dep.startswith("-e"):
+            continue
+        req_file.write(f"{dep}\n")
+
+
+def collect_pip_install_flags(deps_list: Iterable[Dependencies]) -> list[str]:
+    """Collect unique pip_install_flags across a set of library dependencies.
+
+    Order is preserved and duplicates are dropped so the flags can be passed on
+    a single ``uv pip install`` command line.
+    """
+    flags: list[str] = []
+    for deps in deps_list:
+        for flag in deps.pip_install_flags or []:
+            if flag not in flags:
+                flags.append(flag)
+    return flags
+
+
+def ensure_conda_package(conda_packages: str, package: str) -> str:
+    """Ensure a package name is present in a space-separated conda packages string.
+
+    A package is considered present if its bare name matches (ignoring any
+    ``=version`` suffix), so ``python=3.12`` counts as ``python`` already present.
+    """
+    present = {token.split("=", 1)[0] for token in conda_packages.split()}
+    if package not in present:
+        conda_packages = f"{conda_packages} {package}".strip()
+    return conda_packages
+
+
+def build_venv_script() -> str:
+    """Return the worker environment setup script (Open Job Description onEnter).
+
+    The script resolves the Python 3.12 interpreter from the conda queue
+    environment, installs dependencies with uv (which understands the uv-only
+    ``PipInstallFlags``), and symlinks that interpreter into each library's
+    ``.venv/bin/python``.
+
+    ``{{Param.*}}`` tokens are Open Job Description parameter macros and must be
+    preserved verbatim.
+    """
+    return """#!/bin/env bash
+set -e
+echo 'Setting up Python virtual environment...'
+
+# Resolve the Python 3.12 interpreter from the conda queue environment. The
+# default worker AMI's system python is 3.11, which cannot resolve the engine
+# (requires-python >=3.12,<3.13), so never trust a bare `python` on PATH.
+if [ -n "$CONDA_PREFIX" ] && [ -x "$CONDA_PREFIX/bin/python" ]; then
+    TARGET_PYTHON="$CONDA_PREFIX/bin/python"
+else
+    TARGET_PYTHON="$(command -v python3.12 || command -v python)"
+fi
+echo "Using Python interpreter: $TARGET_PYTHON"
+if ! "$TARGET_PYTHON" --version 2>&1 | grep -q ' 3.12'; then
+    echo "ERROR: expected Python 3.12 but found $("$TARGET_PYTHON" --version 2>&1)." >&2
+    echo "Ensure the queue's conda environment provides python=3.12." >&2
+    exit 1
+fi
+
+# Ensure uv is available. Prefer conda-provided uv; otherwise install the
+# standalone binary so the default worker AMI still works.
+if command -v uv >/dev/null 2>&1; then
+    UV_BIN="$(command -v uv)"
+else
+    echo 'uv not found; installing standalone uv...'
+    export UV_INSTALL_DIR="{{Param.LocationToRemap}}/.uv-bin"
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    UV_BIN="$UV_INSTALL_DIR/uv"
+fi
+echo "Using uv: $UV_BIN"
+
+echo 'Installing dependencies...'
+"$UV_BIN" pip install --python "$TARGET_PYTHON" {{Param.PipInstallFlags}} -r {{Param.LocationToRemap}}/assets/requirements.txt
+mkdir -p {{Param.LocationToRemap}}/output
+
+# Create .venv symlinks in libraries so library code that expects its own
+# venv (e.g. _get_library_env_python) finds a working Python with all deps.
+for lib_dir in {{Param.LocationToRemap}}/assets/libraries/*/; do
+    if [ -f "${lib_dir}griptape-nodes-library.json" ] || [ -f "${lib_dir}griptape-nodes-library-cuda129.json" ]; then
+        mkdir -p "${lib_dir}.venv/bin"
+        ln -sf "$TARGET_PYTHON" "${lib_dir}.venv/bin/python"
+        echo "Created .venv symlink in ${lib_dir}"
+    fi
+done
+
+echo 'Virtual environment setup complete.'
+"""
 
 
 def get_metadata_dir_name() -> str | None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,10 @@ dependencies = [
 dev = ["mdformat>=0.7.22", "pyright>=1.1.396", "pytest-asyncio>=0.21.0", "ruff>=0.11.0", "typos>=1.30.2", "openapi-python-client>=0.24.3"]
 test = ["pytest>=8.3.5"]
 
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["griptape_nodes_library_deadline_cloud"]
+
 [tool.ruff]
 line-length = 120
 
@@ -63,6 +67,17 @@ exclude = [
   "griptape_nodes_library_deadline_cloud/workflows/**"
 ]
 
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = [
+  "S101",   # asserts are expected in tests
+  "D103",   # test functions do not need docstrings
+  "S108",   # hardcoded /tmp paths in fixtures are fine
+  "INP001", # tests are not an importable package
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["publish", "execution"]
+
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 
@@ -73,6 +88,7 @@ extend-exclude = ["griptape_nodes_library_deadline_cloud/workflows"]
 venvPath = "."
 venv = ".venv"
 include = ["."]
+extraPaths = ["griptape_nodes_library_deadline_cloud"]
 exclude = [
   "LICENSE",
   ".venv",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+"""Pytest configuration for the Deadline Cloud library tests.
+
+The library modules import each other as a top-level ``publish`` package (e.g.
+``from publish.utils import ...``), mirroring how the engine adds the library
+directory to ``sys.path`` at load time. Replicate that here so the tests can
+import the modules directly.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_LIBRARY_DIR = Path(__file__).resolve().parent.parent / "griptape_nodes_library_deadline_cloud"
+if str(_LIBRARY_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIBRARY_DIR))

--- a/tests/publish/test_conda_packages.py
+++ b/tests/publish/test_conda_packages.py
@@ -1,0 +1,22 @@
+"""Tests for conda-package injection helpers."""
+
+from __future__ import annotations
+
+from publish.utils import ensure_conda_package
+
+
+def test_adds_missing_package() -> None:
+    assert ensure_conda_package("python=3.12 git", "uv") == "python=3.12 git uv"
+
+
+def test_idempotent_when_already_present() -> None:
+    assert ensure_conda_package("python=3.12 git uv", "uv") == "python=3.12 git uv"
+
+
+def test_ignores_version_suffix_when_matching() -> None:
+    # "python=3.12" already provides "python"; do not append a bare "python".
+    assert ensure_conda_package("python=3.12 git", "python") == "python=3.12 git"
+
+
+def test_adds_to_empty_string() -> None:
+    assert ensure_conda_package("", "uv") == "uv"

--- a/tests/publish/test_requirements_generation.py
+++ b/tests/publish/test_requirements_generation.py
@@ -1,0 +1,61 @@
+"""Tests for requirements.txt generation from library dependencies.
+
+Regression coverage for issue #106: uv-only ``pip_install_flags`` (e.g.
+``--preview``, ``--torch-backend=auto``) must NOT be written into
+requirements.txt, because the worker's plain pip would reject them. Instead they
+are collected and passed on the ``uv pip install`` command line.
+"""
+
+from __future__ import annotations
+
+import io
+
+from griptape_nodes.node_library.library_registry import Dependencies
+
+from publish.utils import collect_pip_install_flags, write_library_deps
+
+
+def _render(deps: Dependencies) -> str:
+    buffer = io.StringIO()
+    write_library_deps(buffer, deps)
+    return buffer.getvalue()
+
+
+def test_pip_dependencies_written_one_per_line() -> None:
+    deps = Dependencies(pip_dependencies=["torch==2.7.0", "diffusers>=0.30"])
+    lines = _render(deps).splitlines()
+    assert lines == ["torch==2.7.0", "diffusers>=0.30"]
+
+
+def test_pip_install_flags_are_not_written_to_requirements() -> None:
+    deps = Dependencies(
+        pip_dependencies=["torch==2.7.0"],
+        pip_install_flags=["--preview", "--torch-backend=auto"],
+    )
+    rendered = _render(deps)
+    assert "--preview" not in rendered
+    assert "--torch-backend" not in rendered
+    assert rendered.splitlines() == ["torch==2.7.0"]
+
+
+def test_editable_installs_are_skipped() -> None:
+    deps = Dependencies(pip_dependencies=["-e ./local-checkout", "torch==2.7.0"])
+    assert _render(deps).splitlines() == ["torch==2.7.0"]
+
+
+def test_empty_dependencies_write_nothing() -> None:
+    assert _render(Dependencies()) == ""
+
+
+def test_collect_pip_install_flags_dedupes_preserving_order() -> None:
+    a = Dependencies(pip_install_flags=["--preview", "--torch-backend=auto"])
+    b = Dependencies(pip_install_flags=["--torch-backend=auto", "--index-strategy=unsafe"])
+    assert collect_pip_install_flags([a, b]) == [
+        "--preview",
+        "--torch-backend=auto",
+        "--index-strategy=unsafe",
+    ]
+
+
+def test_collect_pip_install_flags_handles_none() -> None:
+    assert collect_pip_install_flags([Dependencies(pip_dependencies=["torch"])]) == []

--- a/tests/publish/test_venv_script_generation.py
+++ b/tests/publish/test_venv_script_generation.py
@@ -1,0 +1,62 @@
+"""Tests for the worker environment setup script and job template generation.
+
+Regression coverage for issue #106 and its follow-up: the worker must install
+with uv (which understands the uv-only flags) and must target the conda Python
+3.12 interpreter rather than the AMI's system Python 3.11.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from publish.deadline_cloud_job_template_generator import DeadlineCloudJobTemplateGenerator
+from publish.utils import build_venv_script
+
+
+def test_venv_script_installs_with_uv_not_plain_pip() -> None:
+    script = build_venv_script()
+    assert '"$UV_BIN" pip install' in script
+    # The old broken form ran plain pip directly against requirements.txt.
+    assert "\npip install -r" not in script
+    assert "python -m pip install --upgrade" not in script
+
+
+def test_venv_script_targets_conda_python_312() -> None:
+    script = build_venv_script()
+    assert "CONDA_PREFIX" in script
+    assert '--python "$TARGET_PYTHON"' in script
+    # Fails fast instead of looping when the interpreter is not 3.12.
+    assert "grep -q ' 3.12'" in script
+    assert "exit 1" in script
+
+
+def test_venv_script_preserves_ojd_macros() -> None:
+    script = build_venv_script()
+    assert "{{Param.LocationToRemap}}" in script
+    assert "{{Param.PipInstallFlags}}" in script
+
+
+def test_generate_job_template_bakes_flags_and_uv() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        template = DeadlineCloudJobTemplateGenerator.generate_job_template(
+            Path(tmp),
+            "My Workflow",
+            ["/tmp/lib"],
+            pip_install_flags=["--preview", "--torch-backend=auto"],
+        )
+
+    params = {p["name"]: p for p in template["parameterDefinitions"]}
+    assert "uv" in params["CondaPackages"]["default"].split()
+    assert params["PipInstallFlags"]["default"] == "--preview --torch-backend=auto"
+
+
+def test_generate_job_template_defaults_flags_to_empty_string() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        template = DeadlineCloudJobTemplateGenerator.generate_job_template(
+            Path(tmp),
+            "My Workflow",
+            ["/tmp/lib"],
+        )
+    params = {p["name"]: p for p in template["parameterDefinitions"]}
+    assert params["PipInstallFlags"]["default"] == ""


### PR DESCRIPTION
Closes aws-deadline/deadline-cloud#106

## uv-based worker install (issue aws-deadline/deadline-cloud#106)

Libraries can declare uv-only `pip_install_flags` (e.g. `--preview`, `--torch-backend=auto`) in `griptape-nodes-library.json`. The publisher wrote them verbatim into `requirements.txt` and the worker ran plain `pip install`, which rejected them, so EnvEnter looped forever. Separately, the `Python312_Venv` setup script called bare `python`/`pip` from `$PATH`, which on the default worker AMI is system Python 3.11 — the engine (`requires-python >=3.12,<3.13`) then failed to resolve.

Adopt uv on the worker:
- `build_venv_script()` (new, in `publish/utils.py`) resolves the conda 3.12 interpreter, fails fast if it is not 3.12 (instead of looping), installs with `uv pip install --python "$TARGET_PYTHON" {{Param.PipInstallFlags}}`, and symlinks that interpreter into each library's `.venv/bin/python`.
- Stop writing `pip_install_flags` into `requirements.txt`; collect them across referenced libraries (including the no-deps sibling-JSON fallback) and pass them via a new `PipInstallFlags` job parameter.
- Add `uv` to the `CondaPackages` defaults and inject it into user-supplied conda packages at submission (`_ensure_conda_uv`).

Centralize the duplicated requirements-writing and venv-script logic in `publish/utils.py`. Add the repo's first unit tests covering requirements generation, venv-script generation, and conda-package helpers.

## Windows long-path (MAX_PATH) handling

On Windows, the Deadline SDK's job-attachments upload code stats input paths without applying the `\\?\` long-path prefix, so paths over 260 chars are silently marked non-existent and demoted to `referenced_paths` — never uploaded to S3. This is an upstream SDK bug, reported at [aws-deadline/deadline-cloud-job-attachments#51](https://github.com/aws-deadline/deadline-cloud-job-attachments/issues/51); the changes below are a client-side workaround until it's fixed.
- Shorten the packaging temp-dir prefixes (`gtn-dc-`, `gtn-dc-mt-`) so bundle roots stay short and leaves stay under MAX_PATH.
- `expand_directories_to_files()` now walks each input directory from a `\\?\`-prefixed root so `os.walk` can descend into and stat over-long paths, then strips the prefix from the returned paths so downstream SDK/boto3 code sees plain paths.

## Package-name and git-root detection fixes

- Look up the engine distribution as `griptape-nodes-engine` (not `griptape_nodes`), matching the published package name.
- Anchor the git-root walk on the source path from `direct_url.json` rather than `dist.locate_file("")`. With uv-managed editable installs the dist's on-disk location is a build-cache dir with no `.git` ancestor, so the walk always failed and the install was misclassified as `file` instead of git-based.

## TODO
- [x] Run this on a real Deadline Cloud worker
