### PR TITLE
feat: fix worker environment and add attachment path remapping for inference workflows

### DIFF
--- a/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_job_template_generator.py
+++ b/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_job_template_generator.py
@@ -3,12 +3,10 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from pathlib import Path
+from typing import Any
 
 import yaml
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 logger = logging.getLogger("job_template_generator")
 
@@ -18,9 +16,15 @@ class DeadlineCloudJobTemplateGenerator:
 
     @staticmethod
     def generate_job_template(
-        job_bundle_dir: Path, workflow_name: str, library_paths: list[str], *, pickle_control_flow_result: bool = False
+        job_bundle_dir: Path,
+        workflow_name: str,
+        library_paths: list[str],
+        *,
+        pickle_control_flow_result: bool = False,
+        attachment_input_file_paths: list[str] | None = None,
     ) -> dict[str, Any]:
         """Generate Open Job Description template for the workflow."""
+        attachment_input_file_paths = attachment_input_file_paths or []
         parameter_definitions: list[dict[str, Any]] = []
 
         parameter_definitions.append(
@@ -85,27 +89,45 @@ class DeadlineCloudJobTemplateGenerator:
             }
         )
 
+        # Add PATH parameters for attachment input files so Deadline Cloud
+        # natively remaps their paths on the worker.
+        for i, file_path in enumerate(attachment_input_file_paths):
+            parameter_definitions.append(
+                {
+                    "name": f"AttachmentInput_{i}",
+                    "type": "PATH",
+                    "objectType": "FILE",
+                    "dataFlow": "IN",
+                    "description": f"Attachment input file: {Path(file_path).name}",
+                    "default": file_path,
+                }
+            )
+
         # Generate Python execution script
         python_script = DeadlineCloudJobTemplateGenerator._generate_python_execution_script(
-            library_paths, pickle_control_flow_result=pickle_control_flow_result
+            library_paths,
+            pickle_control_flow_result=pickle_control_flow_result,
         )
 
         venv_script = """#!/bin/env bash
 set -e
 echo 'Setting up Python virtual environment...'
+python -m ensurepip --upgrade 2>/dev/null || true
 python -m pip install --upgrade pip wheel setuptools
 echo 'Installing dependencies...'
+export TMPDIR={{Param.LocationToRemap}}/pip_tmp
+mkdir -p "$TMPDIR"
 pip install -r {{Param.LocationToRemap}}/assets/requirements.txt
+rm -rf "$TMPDIR"
 mkdir -p {{Param.LocationToRemap}}/output
 
 # Create .venv symlinks in libraries so library code that expects its own
 # venv (e.g. _get_library_env_python) finds a working Python with all deps.
 SESSION_PYTHON=$(which python)
 for lib_dir in {{Param.LocationToRemap}}/assets/libraries/*/; do
-    if [ -f "${lib_dir}griptape-nodes-library.json" ] || [ -f "${lib_dir}griptape-nodes-library-cuda129.json" ]; then
-        mkdir -p "${lib_dir}.venv/bin"
-        ln -sf "$SESSION_PYTHON" "${lib_dir}.venv/bin/python"
-        echo "Created .venv symlink in ${lib_dir}"
+    if ls "${lib_dir}"griptape-nodes-library*.json 1>/dev/null 2>&1; then
+        "$SESSION_PYTHON" -m venv --system-site-packages "${lib_dir}.venv"
+        echo "Created .venv in ${lib_dir}"
     fi
 done
 
@@ -143,6 +165,14 @@ echo 'Virtual environment setup complete.'
                                     "{{Task.File.Run}}",
                                     "--input-file",
                                     "{{Param.InputFile}}",
+                                    *[
+                                        arg
+                                        for i, original_path in enumerate(attachment_input_file_paths)
+                                        for arg in (
+                                            "--attachment-path",
+                                            f"{original_path}::{{{{Param.AttachmentInput_{i}}}}}",
+                                        )
+                                    ],
                                 ],
                             }
                         },
@@ -161,7 +191,11 @@ echo 'Virtual environment setup complete.'
         return job_template
 
     @staticmethod
-    def _generate_python_execution_script(library_paths: list[str], *, pickle_control_flow_result: bool = False) -> str:
+    def _generate_python_execution_script(
+        library_paths: list[str],
+        *,
+        pickle_control_flow_result: bool = False,
+    ) -> str:
         """Generate the Python script that will execute the Griptape workflow."""
         library_paths_str = ", ".join(repr(path) for path in library_paths)
 
@@ -262,7 +296,6 @@ _set_config(LIBRARIES)
 
 from deadline_cloud_workflow_executor import DeadlineCloudWorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
-from workflow import execute_workflow  # type: ignore[attr-defined]
 
 if __name__ == "__main__":
 
@@ -278,10 +311,44 @@ if __name__ == "__main__":
         default={pickle_control_flow_result},
         help="Whether to pickle the control flow result",
     )
+    parser.add_argument(
+        "--attachment-path",
+        action="append",
+        default=[],
+        help="Path mapping in format 'original_path::worker_path'",
+    )
 
     args = parser.parse_args()
     input_file_path = args.input_file
     pickle_result = args.pickle_control_flow_result
+
+    # Monkey-patch pickle.loads to remap attachment paths as values are unpickled.
+    # Uses exact match (val == orig) to avoid double-replacement issues.
+    _attachment_path_map = {{}}
+    for mapping in args.attachment_path:
+        original, resolved = mapping.split("::", 1)
+        _attachment_path_map[original] = resolved
+        logger.info("Attachment path mapping: %s -> %s", original, resolved)
+
+    if _attachment_path_map:
+        import pickle
+        _original_pickle_loads = pickle.loads
+        def _patched_pickle_loads(data, **kwargs):
+            result = _original_pickle_loads(data, **kwargs)
+            def _remap(val):
+                if isinstance(val, str):
+                    if val in _attachment_path_map:
+                        return _attachment_path_map[val]
+                    return val
+                elif isinstance(val, list):
+                    return [_remap(v) for v in val]
+                elif isinstance(val, dict):
+                    return {{_remap(k): _remap(v) for k, v in val.items()}}
+                return val
+            return _remap(result)
+        pickle.loads = _patched_pickle_loads
+
+    from workflow import execute_workflow  # type: ignore[attr-defined]
 
     try:
         if input_file_path:

--- a/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_multi_task_publisher.py
+++ b/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_multi_task_publisher.py
@@ -861,9 +861,18 @@ class DeadlineCloudMultiTaskPublisher(DeadlineCloudPublisher):
                         # Get the suffix after the output segment base
                         suffix = val[segment_idx + len(output_segment) :]
                         return local_output_path + suffix
+                # Strip worker session prefix from paths that were remapped by job attachments.
+                # Worker paths look like: /sessions/session-.../assetroot-.../<original_path>
+                # Restore to the original local path to prevent the editor from storing worker paths.
+                if val.startswith("/sessions/session-"):
+                    import re as _re
+
+                    match = _re.match(r"/sessions/session-[^/]+/assetroot-[^/]+(/.*)", val)
+                    if match:
+                        return match.group(1)
                 return val
             if isinstance(val, dict):
-                return {k: translate_value(v) for k, v in val.items()}
+                return {translate_value(k): translate_value(v) for k, v in val.items()}
             if isinstance(val, list):
                 return [translate_value(item) for item in val]
             return val

--- a/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_multi_task_template_generator.py
+++ b/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_multi_task_template_generator.py
@@ -129,10 +129,9 @@ mkdir -p {{Param.LocationToRemap}}/output
 # venv (e.g. _get_library_env_python) finds a working Python with all deps.
 SESSION_PYTHON=$(which python)
 for lib_dir in {{Param.LocationToRemap}}/assets/libraries/*/; do
-    if [ -f "${lib_dir}griptape-nodes-library.json" ] || [ -f "${lib_dir}griptape-nodes-library-cuda129.json" ]; then
-        mkdir -p "${lib_dir}.venv/bin"
-        ln -sf "$SESSION_PYTHON" "${lib_dir}.venv/bin/python"
-        echo "Created .venv symlink in ${lib_dir}"
+    if ls "${lib_dir}"griptape-nodes-library*.json 1>/dev/null 2>&1; then
+        "$SESSION_PYTHON" -m venv --system-site-packages "${lib_dir}.venv"
+        echo "Created .venv in ${lib_dir}"
     fi
 done
 

--- a/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_publisher.py
+++ b/griptape_nodes_library_deadline_cloud/publish/deadline_cloud_publisher.py
@@ -1013,7 +1013,7 @@ class DeadlineCloudPublisher(BaseDeadlineCloud):
         for key, val in env_file_dict.items():
             set_key(env_file_path, key, str(val))
 
-    def _write_deps_from_sibling_json(self, library_name: str, req_file: Any) -> None:
+    def _write_deps_from_sibling_json(self, library_name: str, req_file: Any) -> None:  # noqa: C901
         """Look for a sibling library JSON with pip_dependencies.
 
         When a library is registered with a no-deps variant, look for the full
@@ -1041,7 +1041,26 @@ class DeadlineCloudPublisher(BaseDeadlineCloud):
                 if pip_deps:
                     pip_flags = deps.get("pip_install_flags", [])
                     if pip_flags:
-                        req_file.write(f"{' '.join(pip_flags)}\n")
+                        has_torch_backend = any("--torch-backend" in f for f in pip_flags)
+                        pip_compatible_flags = [
+                            f
+                            for f in pip_flags
+                            if f.startswith(
+                                (
+                                    "--extra-index-url",
+                                    "--find-links",
+                                    "--index-url",
+                                    "--no-deps",
+                                    "--prefer-binary",
+                                    "https://",
+                                )
+                            )
+                            or f == "--pre"
+                        ]
+                        if has_torch_backend and not any("pytorch.org" in f for f in pip_compatible_flags):
+                            pip_compatible_flags.extend(["--extra-index-url", "https://download.pytorch.org/whl/cu129"])
+                        if pip_compatible_flags:
+                            req_file.write(f"{' '.join(pip_compatible_flags)}\n")
                     for dep in pip_deps:
                         if dep.startswith("-e"):
                             continue
@@ -1170,7 +1189,28 @@ class DeadlineCloudPublisher(BaseDeadlineCloud):
                     deps = library_data.metadata.dependencies
                     if deps and deps.pip_dependencies:
                         if deps.pip_install_flags:
-                            req_file.write(f"{' '.join(deps.pip_install_flags)}\n")
+                            has_torch_backend = any("--torch-backend" in f for f in deps.pip_install_flags)
+                            pip_compatible_flags = [
+                                f
+                                for f in deps.pip_install_flags
+                                if f.startswith(
+                                    (
+                                        "--extra-index-url",
+                                        "--find-links",
+                                        "--index-url",
+                                        "--no-deps",
+                                        "--prefer-binary",
+                                        "https://",
+                                    )
+                                )
+                                or f == "--pre"
+                            ]
+                            if has_torch_backend and not any("pytorch.org" in f for f in pip_compatible_flags):
+                                pip_compatible_flags.extend(
+                                    ["--extra-index-url", "https://download.pytorch.org/whl/cu129"]
+                                )
+                            if pip_compatible_flags:
+                                req_file.write(f"{' '.join(pip_compatible_flags)}\n")
                         for dep in deps.pip_dependencies:
                             if dep.startswith("-e"):
                                 continue
@@ -1183,12 +1223,20 @@ class DeadlineCloudPublisher(BaseDeadlineCloud):
             if file_selector_nodes:
                 self._resolve_and_copy_static_files(file_selector_nodes, assets_dir)
 
+            # 6b. Collect attachment_input_paths for PATH parameter registration
+            start_flow_input = self._create_run_input.get("Deadline Cloud Start Flow", {})
+            attachment_input_file_paths = start_flow_input.get("attachment_input_paths", [])
+
             # 7. Write Deadline-specific project template (always, even without FileSelector nodes)
             self._write_deadline_project_template(assets_dir)
 
             # 8. Generate Job Template
             self._job_template = DeadlineCloudJobTemplateGenerator.generate_job_template(
-                job_bundle_dir, workflow_name, library_paths, pickle_control_flow_result=self.pickle_control_flow_result
+                job_bundle_dir,
+                workflow_name,
+                library_paths,
+                pickle_control_flow_result=self.pickle_control_flow_result,
+                attachment_input_file_paths=attachment_input_file_paths,
             )
 
             logger.info("Job bundle created at: %s", job_bundle_dir)


### PR DESCRIPTION
## Summary

Fixes multiple issues that prevent LoRA inference workflows from running on Deadline Cloud workers:

- **Worker pip bootstrap**: Add `ensurepip` for workers where `.env` virtualenv doesn't have pip pre-installed
- **TMPDIR redirect**: Use root disk for pip builds to avoid tmpfs "No space left on device" during `sam2` build deps
- **pip flag filter**: Strip uv-specific flags (`--preview`, `--torch-backend=auto`) from requirements.txt; inject `--extra-index-url https://download.pytorch.org/whl/cu129` when torch backend is needed
- **Broader .venv glob**: Match any `griptape-nodes-library*.json` variant (supports `-no-deps.json` registration on Mac)
- **Real venv instead of symlink**: Use `python -m venv --system-site-packages` for library `.venv` creation (fixes `import accelerate` failures)
- **Attachment path remapping**: Register `attachment_input_paths` as PATH-type template parameters so Deadline Cloud natively resolves them; monkey-patch `pickle.loads` in task script to remap paths in serialized workflow values
- **Worker path cleanup**: Strip `/sessions/session-xxx/assetroot-xxx/` prefix in `_translate_worker_paths_to_local` to prevent editor from storing worker-specific paths

## Test plan

- [ ] Submit LoRA training workflow → verify `.venv` creation works with `-no-deps.json`
- [ ] Submit inference workflow with `attachment_input_paths` → verify file is accessible on worker at remapped path
- [ ] Verify pip installs without `--preview` error
- [ ] Verify no "No space left on device" during pip builds
- [ ] After job completes, verify Load LoRA `file_path` retains local path in editor (not worker session path)